### PR TITLE
feat: Scaffold initial microservices backend

### DIFF
--- a/packages/integrations-service/Dockerfile
+++ b/packages/integrations-service/Dockerfile
@@ -1,0 +1,23 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json (if available)
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the TypeScript code
+RUN npm run build
+
+# The service will run on port 3002
+EXPOSE 3002
+
+# Command to run the application
+CMD [ "node", "dist/index.js" ]

--- a/packages/integrations-service/package.json
+++ b/packages/integrations-service/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "integrations-service",
+  "version": "1.0.0",
+  "description": "Handles third-party integrations",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc",
+    "serve": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.8",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6"
+  }
+}

--- a/packages/integrations-service/src/index.ts
+++ b/packages/integrations-service/src/index.ts
@@ -1,0 +1,14 @@
+import express, { Request, Response } from 'express';
+
+const app = express();
+const port = process.env.PORT || 3002;
+
+app.use(express.json());
+
+app.get('/integrations', (req: Request, res: Response) => {
+  res.json({ message: 'This is the integrations service' });
+});
+
+app.listen(port, () => {
+  console.log(`Integrations service running on port ${port}`);
+});

--- a/packages/integrations-service/tsconfig.json
+++ b/packages/integrations-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/users-service/Dockerfile
+++ b/packages/users-service/Dockerfile
@@ -1,0 +1,23 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json (if available)
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the TypeScript code
+RUN npm run build
+
+# The service will run on port 3001
+EXPOSE 3001
+
+# Command to run the application
+CMD [ "node", "dist/index.js" ]

--- a/packages/users-service/package.json
+++ b/packages/users-service/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "users-service",
+  "version": "1.0.0",
+  "description": "User management microservice",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc",
+    "serve": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.8",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6"
+  }
+}

--- a/packages/users-service/src/index.ts
+++ b/packages/users-service/src/index.ts
@@ -1,0 +1,14 @@
+import express, { Request, Response } from 'express';
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.get('/users', (req: Request, res: Response) => {
+  res.json({ message: 'This is the users service' });
+});
+
+app.listen(port, () => {
+  console.log(`Users service running on port ${port}`);
+});

--- a/packages/users-service/tsconfig.json
+++ b/packages/users-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This commit introduces the initial structure for the backend microservices.

Following a monorepo pattern, a `packages` directory has been created to house the individual services. Two services have been scaffolded:

- `users-service`: A service for user management.
- `integrations-service`: A service to handle third-party integrations.

Each service is a self-contained Node.js/TypeScript application built with Express. They include a `package.json` for dependencies, a `tsconfig.json` for TypeScript compilation, a basic `index.ts` with a sample endpoint, and a `Dockerfile` for containerization.

This provides a foundational architecture for future backend development.