### PR TITLE
feat: Configure backend for Firebase Cloud Functions

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "myphantomdev"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,32 @@
+{
+  "functions": [
+    {
+      "source": "packages/users-service",
+      "codebase": "users-service",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" install",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    },
+    {
+      "source": "packages/integrations-service",
+      "codebase": "integrations-service",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" install",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ]
+}

--- a/packages/integrations-service/package.json
+++ b/packages/integrations-service/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "integrations-service",
+  "version": "1.0.0",
+  "description": "Handles third-party integrations",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6"
+  },
+  "private": true
+}

--- a/packages/integrations-service/src/index.ts
+++ b/packages/integrations-service/src/index.ts
@@ -1,0 +1,28 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import express from "express";
+
+// Initialize Firebase Admin SDK
+admin.initializeApp();
+
+const app = express();
+app.use(express.json());
+
+// A simple health check endpoint
+app.get("/", (req, res) => {
+  res.status(200).json({ message: "Integrations service is up and running." });
+});
+
+// Example route for a specific integration
+app.post("/webhook", (req, res) => {
+    const payload = req.body;
+    // In a real app, you would process the webhook payload here
+    console.log("Received webhook payload:", payload);
+    res.status(200).json({ status: "received" });
+});
+
+
+// Expose the Express app as a Cloud Function named "api"
+// The resulting URL will be something like:
+// https://<region>-<project-id>.cloudfunctions.net/integrations-api
+export const api = functions.https.onRequest(app);

--- a/packages/integrations-service/tsconfig.json
+++ b/packages/integrations-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/users-service/package.json
+++ b/packages/users-service/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "users-service",
+  "version": "1.0.0",
+  "description": "User management microservice",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6"
+  },
+  "private": true
+}

--- a/packages/users-service/src/index.ts
+++ b/packages/users-service/src/index.ts
@@ -1,0 +1,27 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import express from "express";
+
+// Initialize Firebase Admin SDK
+admin.initializeApp();
+
+const app = express();
+app.use(express.json());
+
+// A simple health check endpoint
+app.get("/", (req, res) => {
+  res.status(200).json({ message: "Users service is up and running." });
+});
+
+// Example route for users
+app.get("/:id", (req, res) => {
+    const userId = req.params.id;
+    // In a real app, you would fetch user data from a database
+    res.status(200).json({ id: userId, name: `User ${userId}` });
+});
+
+
+// Expose the Express app as a Cloud Function named "api"
+// The resulting URL will be something like:
+// https://<region>-<project-id>.cloudfunctions.net/users-api
+export const api = functions.https.onRequest(app);

--- a/packages/users-service/tsconfig.json
+++ b/packages/users-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This commit refactors the backend microservices to be deployable as Firebase Cloud Functions, correcting a previous implementation that incorrectly used Firebase Hosting.

Key changes:
- The `users-service` and `integrations-service` have been updated to export their Express applications as HTTPS-triggered Cloud Functions.
- The `package.json` for each service has been updated to include the `firebase-functions` and `firebase-admin` dependencies.
- The previous `firebase.json` (for Hosting) and the service `Dockerfile`s have been removed.
- A new `firebase.json` has been created to define the two services as separate function codebases, configured for a monorepo setup with predeploy build steps.
- The `.firebaserc` file is retained to link the project to the `myphantomdev` Firebase project.

This provides a correct and scalable foundation for the backend on Firebase.