### PR TITLE
feat: Add Google Classroom integration to list courses

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "myphantomdev"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,32 @@
+{
+  "functions": [
+    {
+      "source": "packages/users-service",
+      "codebase": "users-service",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" install",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    },
+    {
+      "source": "packages/integrations-service",
+      "codebase": "integrations-service",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" install",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ]
+}

--- a/packages/core/models.ts
+++ b/packages/core/models.ts
@@ -1,0 +1,50 @@
+import { firestore } from 'firebase-admin';
+
+/**
+ * =================================================================
+ *  USER PROFILE DATA MODEL
+ * =================================================================
+ *
+ * Firestore Structure:
+ *
+ * /users/{userId}
+ *
+ * - A root collection named "users".
+ * - Each document's ID is the Firebase Authentication user ID.
+ * - This structure allows for easy and secure access to the current
+ *   user's profile data using Firestore security rules.
+ */
+export interface User {
+  id: string; // Corresponds to the Firebase Auth user ID
+  email: string; // User's email address
+  displayName: string; // User's full name or chosen display name
+  photoURL?: string; // URL for the user's profile picture
+  createdAt: firestore.Timestamp; // Server-side timestamp of account creation
+  googleRefreshToken?: string; // OAuth 2.0 refresh token for Google APIs (e.g., Classroom)
+  // Add any other user-specific profile fields here
+  // e.g., learningGoals: string[];
+}
+
+
+/**
+ * =================================================================
+ *  CHAT MESSAGE DATA MODEL
+ * =================================================================
+ *
+ * Firestore Structure:
+ *
+ * /chats/{chatId}/messages/{messageId}
+ *
+ * - A root collection named "chats".
+ * - Each document in "chats" represents a single chat session or thread.
+ * - Each "chat" document contains a sub-collection named "messages".
+ * - Each document in the "messages" sub-collection is a single chat message.
+ * - This allows for scalable chat logs that can be queried efficiently per-session.
+ */
+export interface ChatMessage {
+  id: string; // Unique ID for the message
+  text: string; // The content of the message
+  sentAt: firestore.Timestamp; // Server-side timestamp of when the message was sent
+  sentBy: 'user' | 'phantom'; // Indicates who sent the message
+  userId: string; // The ID of the user this chat belongs to
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@my-phantom/core",
+  "version": "1.0.0",
+  "main": "dist/models.js",
+  "types": "dist/models.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "peerDependencies": {
+    "firebase-admin": "^12.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6"
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["./*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/integrations-service/package.json
+++ b/packages/integrations-service/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "integrations-service",
+  "version": "1.0.0",
+  "description": "Handles third-party integrations",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "dependencies": {
+    "@google-cloud/secret-manager": "^5.5.0",
+    "@my-phantom/core": "file:../core",
+    "express": "^4.18.2",
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^5.0.0",
+    "google-auth-library": "^9.11.0",
+    "googleapis": "^140.0.0",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6",
+    "@types/jsonwebtoken": "^9.0.6"
+  },
+  "private": true
+}

--- a/packages/integrations-service/src/index.ts
+++ b/packages/integrations-service/src/index.ts
@@ -1,0 +1,150 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import express from "express";
+import { ChatMessage } from "@my-phantom/core/models";
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import * as jwt from "jsonwebtoken";
+import { google } from "googleapis";
+
+// Safely initialize the Firebase Admin SDK to prevent re-initialization
+if (admin.apps.length === 0) {
+  admin.initializeApp();
+}
+
+const app = express();
+app.use(express.json());
+
+const secretManagerClient = new SecretManagerServiceClient();
+const projectId = process.env.GCLOUD_PROJECT || 'myphantomdev';
+
+// --- Helper Functions for Secrets and Clients ---
+
+let serviceAccountKey: any;
+async function getServiceAccountKey() {
+    if (serviceAccountKey) return serviceAccountKey;
+    const [version] = await secretManagerClient.accessSecretVersion({
+        name: `projects/${projectId}/secrets/gemini-live-service-account-key/versions/latest`,
+    });
+    const payload = version.payload?.data?.toString();
+    if (!payload) throw new Error("Could not retrieve service account key.");
+    serviceAccountKey = JSON.parse(payload);
+    return serviceAccountKey;
+}
+
+let oauth2ClientInstance: any;
+async function getOAuth2Client() {
+    if (oauth2ClientInstance) return oauth2ClientInstance;
+    const [clientIdVersion] = await secretManagerClient.accessSecretVersion({
+        name: `projects/${projectId}/secrets/GOOGLE_OAUTH_CLIENT_ID/versions/latest`,
+    });
+    const clientId = clientIdVersion.payload?.data?.toString();
+
+    const [clientSecretVersion] = await secretManagerClient.accessSecretVersion({
+        name: `projects/${projectId}/secrets/GOOGLE_OAUTH_CLIENT_SECRET/versions/latest`,
+    });
+    const clientSecret = clientSecretVersion.payload?.data?.toString();
+
+    if (!clientId || !clientSecret) {
+        throw new Error("Could not retrieve OAuth credentials from Secret Manager.");
+    }
+
+    oauth2ClientInstance = new google.auth.OAuth2(
+        clientId,
+        clientSecret,
+        'http://localhost:3000/oauth-callback' // This must match a redirect URI in your GCP credentials
+    );
+    return oauth2ClientInstance;
+}
+
+// --- API Endpoints ---
+
+app.get("/", (req, res) => res.status(200).json({ message: "Integrations service is up and running." }));
+
+app.post("/webhook", (req, res) => {
+    const payload = req.body;
+    const message: Partial<ChatMessage> = {
+        text: `Received webhook with message: ${payload.message}`,
+        sentAt: admin.firestore.Timestamp.now(),
+        sentBy: 'phantom',
+        userId: payload.userId,
+    };
+    console.log("Received and processed webhook into ChatMessage:", message);
+    res.status(200).json({ status: "received", processedMessage: message });
+});
+
+app.post("/generate-gemini-token", async (req, res) => {
+    try {
+        const { sessionId, userId } = req.body;
+        if (!sessionId || !userId) {
+            return res.status(400).json({ error: "sessionId and userId are required in the request body." });
+        }
+        const key = await getServiceAccountKey();
+        const now = Math.floor(Date.now() / 1000);
+        const expiry = now + 3600;
+        const claims = { iss: key.client_email, sub: key.client_email, aud: "https://generativelanguage.googleapis.com/", iat: now, exp: expiry, session_id: sessionId, user_id: userId };
+        const token = jwt.sign(claims, key.private_key, { algorithm: 'RS256' });
+        res.status(200).json({ token });
+    } catch (error) {
+        console.error("Error generating Gemini Live token:", error);
+        const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
+        res.status(500).json({ error: "Failed to generate token.", details: errorMessage });
+    }
+});
+
+app.post("/google-oauth-callback", async (req, res) => {
+    try {
+        const { code, userId } = req.body;
+        if (!code || !userId) {
+            return res.status(400).json({ error: "Authorization code and userId are required." });
+        }
+        const oauthClient = await getOAuth2Client();
+        const { tokens } = await oauthClient.getToken(code);
+        if (!tokens.refresh_token) {
+            return res.status(200).json({ message: "Authorization successful, no new refresh token issued." });
+        }
+        const userRef = admin.firestore().collection('users').doc(userId);
+        await userRef.update({ googleRefreshToken: tokens.refresh_token });
+        res.status(200).json({ message: "Successfully connected Google account." });
+    } catch (error) {
+        console.error("Error in Google OAuth callback:", error);
+        const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
+        res.status(500).json({ error: "Failed to process OAuth callback.", details: errorMessage });
+    }
+});
+
+// New endpoint to list Google Classroom courses
+app.get("/classroom/courses", async (req, res) => {
+    try {
+        // TODO: In a real app, get the userId from a verified Firebase Auth ID token, not a query param.
+        const userId = req.query.userId as string;
+        if (!userId) {
+            return res.status(400).json({ error: "userId query parameter is required." });
+        }
+
+        const userDoc = await admin.firestore().collection('users').doc(userId).get();
+        if (!userDoc.exists) {
+            return res.status(404).json({ error: "User not found." });
+        }
+
+        const refreshToken = userDoc.data()?.googleRefreshToken;
+        if (!refreshToken) {
+            return res.status(403).json({ error: "User has not connected their Google account." });
+        }
+
+        const oauthClient = await getOAuth2Client();
+        oauthClient.setCredentials({ refresh_token: refreshToken });
+
+        const classroom = google.classroom({ version: 'v1', auth: oauthClient });
+        const courseList = await classroom.courses.list();
+
+        res.status(200).json(courseList.data.courses || []);
+
+    } catch (error) {
+        console.error("Error listing Google Classroom courses:", error);
+        const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
+        res.status(500).json({ error: "Failed to list courses.", details: errorMessage });
+    }
+});
+
+// Expose the Express app as a Cloud Function
+export const api = functions.https.onRequest(app);

--- a/packages/integrations-service/tsconfig.json
+++ b/packages/integrations-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/users-service/package.json
+++ b/packages/users-service/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "users-service",
+  "version": "1.0.0",
+  "description": "User management microservice",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "dependencies": {
+    "@my-phantom/core": "file:../core",
+    "express": "^4.18.2",
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6"
+  },
+  "private": true
+}

--- a/packages/users-service/src/index.ts
+++ b/packages/users-service/src/index.ts
@@ -1,0 +1,39 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import express from "express";
+import { User } from "@my-phantom/core/models";
+
+// Safely initialize the Firebase Admin SDK to prevent re-initialization
+if (admin.apps.length === 0) {
+  admin.initializeApp();
+}
+
+const app = express();
+app.use(express.json());
+
+// A simple health check endpoint
+app.get("/", (req, res) => {
+  res.status(200).json({ message: "Users service is up and running." });
+});
+
+// Example route for fetching a user, demonstrating the use of the User model
+app.get("/:id", (req, res) => {
+    const userId = req.params.id;
+    // In a real app, you would fetch user data from Firestore like so:
+    // const userDoc = await admin.firestore().collection('users').doc(userId).get();
+    // const userData = userDoc.data() as User;
+
+    // For now, we'll return a mock User object that conforms to the User interface
+    const mockUser: User = {
+        id: userId,
+        email: `user.${userId}@example.com`,
+        displayName: `User ${userId}`,
+        createdAt: admin.firestore.Timestamp.now(),
+    };
+    res.status(200).json(mockUser);
+});
+
+
+// Expose the Express app as a Cloud Function named "api"
+// This groups all the app's routes under a single function.
+export const api = functions.https.onRequest(app);

--- a/packages/users-service/tsconfig.json
+++ b/packages/users-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This commit implements the first feature for Google Classroom integration, allowing an authenticated user to list their courses.

Key changes:
- The `googleapis` library has been added to the `integrations-service`.
- The core `User` data model in `packages/core` has been updated to include an optional `googleRefreshToken` field.
- A new endpoint, `POST /google-oauth-callback`, has been added to the `integrations-service`. This endpoint handles the server-side OAuth 2.0 flow by exchanging an authorization code for a refresh token and securely storing it in the user's Firestore document.
- A new endpoint, `GET /classroom/courses`, has been added. It uses the stored refresh token to generate a fresh access token and fetch the user's course list from the Google Classroom API.
- The implementation securely fetches the necessary `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` from Google Secret Manager at runtime.