### PR TITLE
feat: specify nodejs20 runtime for functions

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,7 +12,8 @@
       "predeploy": [
         "npm --prefix \"$RESOURCE_DIR\" install",
         "npm --prefix \"$RESOURCE_DIR\" run build"
-      ]
+      ],
+      "runtime": "nodejs20"
     },
     {
       "source": "packages/integrations-service",
@@ -26,7 +27,8 @@
       "predeploy": [
         "npm --prefix \"$RESOURCE_DIR\" install",
         "npm --prefix \"$RESOURCE_DIR\" run build"
-      ]
+      ],
+      "runtime": "nodejs20"
     }
   ]
 }


### PR DESCRIPTION
Sets the Node.js runtime to `nodejs20` for all Firebase Functions. This resolves the deployment error "Error: 'runtime' field is required but was not found in firebase.json or package.json".

The runtime is specified in the `firebase.json` file for both the `users-service` and `integrations-service` codebases, providing a centralized and maintainable configuration.