### PR TITLE
fix(build): install core dependencies before build

### DIFF
--- a/packages/api-service/package.json
+++ b/packages/api-service/package.json
@@ -4,6 +4,7 @@
   "description": "Handles third-party integrations",
   "main": "dist/index.js",
   "scripts": {
+    "prebuild": "npm install --prefix ../core",
     "build": "tsc",
     "test": "node --max-old-space-size=4096 node_modules/.bin/jest --runInBand"
   },


### PR DESCRIPTION
The `api-service` package depends on the `core` package. The build was failing because the dependencies of the `core` package, specifically `firebase-admin`, were not being installed.

This change adds a `prebuild` script to `packages/api-service/package.json` to run `npm install` in the `packages/core` directory before the `api-service` build is run. This ensures that all necessary dependencies are in place, resolving the TS2307 error.