### PR TITLE
fix(api-service): Correct build script for deployment

### DIFF
--- a/packages/api-service/package.json
+++ b/packages/api-service/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prebuild": "npm install --prefix ../core",
-    "build": "tsc",
+    "build": "tsc -b",
     "test": "node --max-old-space-size=4096 node_modules/.bin/jest --runInBand"
   },
   "dependencies": {


### PR DESCRIPTION
The `firebase deploy` command was failing with a "Precondition failed" error, which was the first of several issues. After resolving API and authentication issues, the deployment was still failing due to a build error.

The `api-service` package is a composite TypeScript project, which requires the `tsc -b` command to build correctly. The `build` script in `package.json` was using `tsc`, which was causing the build to fail silently (not creating the `dist` directory).

This change updates the `build` script to `tsc -b` to ensure the project is built correctly before deployment. This should resolve the deployment failures when run from a properly authenticated environment.