### PR TITLE
Fix ESLint configuration for Firebase function deployment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    "react-app",
+    "react-app/jest"
+  ],
+  "ignorePatterns": ["packages/api-service/"]
+}

--- a/package.json
+++ b/package.json
@@ -24,12 +24,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
The `firebase deploy --only functions` command was failing due to an ESLint error: "ESLint couldn't find the config 'react-app' to extend from."

This occurred because the deployment command, run from the project root, was incorrectly applying the root-level React ESLint configuration to the backend functions located in the `packages/api-service` directory.

This commit resolves the issue by:
1. Moving the ESLint configuration from `package.json` to a dedicated `.eslintrc.json` file in the project root.
2. Adding an `ignorePatterns` rule to the new `.eslintrc.json` to explicitly exclude the `packages/api-service` directory from the frontend's linting process.

This change isolates the frontend and backend linting configurations, allowing the Firebase deployment to proceed without errors.